### PR TITLE
To avoid field larger than field limit

### DIFF
--- a/csvdiff/__init__.py
+++ b/csvdiff/__init__.py
@@ -9,6 +9,9 @@ from __future__ import absolute_import, print_function, division
 
 import sys
 
+import csv 
+csv.field_size_limit(sys.maxsize)
+
 import click
 
 from . import records, patch, error


### PR DESCRIPTION
This will be helpful to avoid `_csv.Error: field larger than field limit (131072)` issue