### PR TITLE
Raise an error if no index is present

### DIFF
--- a/csvdiff/records.py
+++ b/csvdiff/records.py
@@ -48,6 +48,9 @@ def load(file_or_stream: Any, sep: str=',') -> SafeDictReader:
 
 
 def index(record_seq: Iterator[Record], index_columns: List[str]) -> Index:
+    if not index_columns:
+        raise InvalidKeyError('must provide on or more columns to index on')
+
     try:
         obj = {
             tuple(r[i] for i in index_columns): r


### PR DESCRIPTION
To aid issues such as #39, we want to ensure that programmatic use doesn't avoid specifying primary keys.